### PR TITLE
Warning fix

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -65,14 +65,16 @@ function appInit () {
     require('shell').openExternal(url)
     event.preventDefault();
   });
-  
-  // update OSX badge
-  win.on('page-title-updated', function(event, title) {
-    var unreadCount = getUnreadCount(title);
-    app.dock.setBadge(unreadCount);
-    if (unreadCount > 0)
-      app.dock.bounce('informational');
-  });
+
+  // update OSX badge only if you're using OSX.
+  if(app.hasOwnProperty("dock")) {
+  	win.on('page-title-updated', function(event, title) {
+  	  var unreadCount = getUnreadCount(title);
+  	  app.dock.setBadge(unreadCount);
+  	  if (unreadCount > 0)
+  	    app.dock.bounce('informational');
+  	});
+  }
 
   win.on('close', function(e){
     if (win.forceClose) return;

--- a/app/app.js
+++ b/app/app.js
@@ -67,7 +67,7 @@ function appInit () {
   });
 
   // update OSX badge only if you're using OSX.
-  if(app.hasOwnProperty("dock")) {
+  if(process.platform == 'darwin') {
   	win.on('page-title-updated', function(event, title) {
   	  var unreadCount = getUnreadCount(title);
   	  app.dock.setBadge(unreadCount);


### PR DESCRIPTION
win.on listener gets used only if you're using Mac OSX. I was getting a
warning when the application started and sometimes even using it. Here
is the quick fix :)
