### PR TITLE
Switch contacts without using the mouse

### DIFF
--- a/app/js/injected.js
+++ b/app/js/injected.js
@@ -1,0 +1,27 @@
+(function () {
+
+    console.log("Waiting for DOMContentLoaded");
+    document.addEventListener('DOMContentLoaded', function () {
+        console.log("DOMContentLoaded event");
+
+        // pass in the target node, as well as the observer options
+        var observer = new MutationObserver(function (mutations) {
+            console.log("Mutations occurred: ", mutations.length);
+            var inputSearch = document.querySelector("input.input-search");
+            if (inputSearch) {
+                console.log("Adding event listeners");
+
+                document.addEventListener("keydown", function (event) {
+                    if (event.keyCode === 75 && event.metaKey === true) inputSearch.focus()
+                });
+    
+                console.log("Disconnecting the observer");
+                observer.disconnect();
+            }
+        });
+
+        var config = {childList: true, subtree: true};
+        observer.observe(document.querySelector("body"), config);
+
+    }, false);
+})();

--- a/app/main.js
+++ b/app/main.js
@@ -9,6 +9,8 @@
     var NativeImage = require('native-image');
     var BrowserWindow = require('browser-window');
 
+    var join = require('path').join;
+
     global.onlyOSX = function(callback) {
         if (process.platform === 'darwin') {
             return Function.bind.apply(callback, this, [].slice.call(arguments, 0));
@@ -140,7 +142,8 @@
                 "min-height": 600,
                 "type": "toolbar",
                 "node-integration": false,
-                "title": "WhatsApp"
+                "title": "WhatsApp",
+                "preload": join(__dirname, 'js', 'injected.js')
             });
 
             whatsApp.window.loadUrl('https://web.whatsapp.com', {

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@ This is **NOT** an official product. This project does not attempt to reverse en
 * Open links in browser.  
 * Badge with the number of notifications in the dock/taskbar.  
 * Dock icon bounces when a new message is received.
+* Focus on contact search input via CMD+K (WIN+K)
 * A couple of things can be configured:
   * Display or not the avatars
   * Display or not the preview of the messages


### PR DESCRIPTION
Allow a user to focus on the contact searchbox via CMD+K (similar to slack)
