### PR TITLE
Allow user to speed up audio message playback rates

### DIFF
--- a/app/js/injected.js
+++ b/app/js/injected.js
@@ -16,7 +16,7 @@
                     if ((event.keyCode === 75 || event.keyCode == 70) && event.metaKey === true)
                         inputSearch.focus();
                 });
-    
+
                 console.log("Disconnecting the observer");
                 observer.disconnect();
             }
@@ -26,4 +26,15 @@
         observer.observe(document.querySelector("body"), config);
 
     }, false);
+
+    setInterval(function() {
+        Array.from(document.querySelectorAll('audio')).map(function(audio) {
+            audio.playbackRate = (window.audioRate || 1)
+        });
+        if (window.audioRate) {
+            Array.from(document.querySelectorAll('.meta-audio *:first-child')).map(function(span) {
+                span.innerHTML = window.audioRate.toFixed(1) + "x&nbsp;";
+            });
+        }
+    }, 200);
 })();

--- a/app/menu.js
+++ b/app/menu.js
@@ -43,7 +43,7 @@
                 },
                 {
                     label: 'Settings',
-                    accelerator: 'CmdOrCtrl+',
+                    accelerator: 'CmdOrCtrl+,',
                     click: function () {
                         global.settings.init();
                     }

--- a/app/menu.js
+++ b/app/menu.js
@@ -104,6 +104,29 @@
                     role: 'close'
                 }
             ]
+        },
+        {
+            label: 'Audio',
+            submenu: [
+                {
+                    label: 'Increase Audio Rate by 20%',
+                    accelerator: 'CmdOrCtrl+=',
+                    click: function(item, focusedWindow) {
+                        focusedWindow && focusedWindow.webContents.executeJavaScript(
+                            "window.audioRate = (window.audioRate || 1) + 0.2"
+                        )
+                    }
+                },
+                {
+                    label: 'Decrease Audio Rate by 20%',
+                    accelerator: 'CmdOrCtrl+-',
+                    click: function(item, focusedWindow) {
+                        focusedWindow && focusedWindow.webContents.executeJavaScript(
+                            "window.audioRate = (window.audioRate || 1) - 0.2"
+                        )
+                    }
+                }
+            ]
         }
     ];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whatsapp-desktop",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "repository": "https://github.com/bcalik/Whatsapp-Desktop.git",
   "description": "Unofficial WhatsApp Desktop Client. Build with Electron.",
   "main": "main.js",


### PR DESCRIPTION
User can use CmdOrControl = or - to increment or decrement a global audio playback rate, which shows up (if set) to the left of the audio time text. For conversations with multi-minute messages, this can be an incredible productivity boost.

The preference is not persisted at the moment - if you restart, you need to ramp up your speed again. It's a bit suboptimal, but wanted to release the feature sooner rather than later.
