### PR TITLE
Fix opening links in browser

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -202,7 +202,7 @@
             }));
 
             whatsApp.window.webContents.on("new-window", (e, url) => {
-                require('shell').openExternal(url);
+                require('electron').shell.openExternal(url);
                 e.preventDefault();
             });
 


### PR DESCRIPTION
Because I updated to a newer electron version of electron in my previous PR opening links did not work anymore. This is fixed now by using the new require syntax 😊 .