### PR TITLE
Prevent the App from getting multiple instances

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -11,6 +11,19 @@
 
     var join = require('path').join;
 
+    const isAlreadyRunning = app.makeSingleInstance(() => {
+        if (whatsApp.window) {
+            if (whatsApp.window.isMinimized()) {
+                whatsApp.window.restore();
+            }
+            whatsApp.window.show();
+        }
+    });
+
+    if (isAlreadyRunning) {
+        app.quit();
+    }
+
     global.onlyOSX = function(callback) {
         if (process.platform === 'darwin') {
             return Function.bind.apply(callback, this, [].slice.call(arguments, 0));


### PR DESCRIPTION
I got the code from the Caprine App to prevent multiple instances.

I only tested the code on Linux.

Now when the App is only in the System Tray and I click again in the
launcher it will reopen it instead of opening a new instance.