### PR TITLE
Shows icon when running under linux

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -178,6 +178,7 @@
                 "minHeight": 600,
                 //"type": "toolbar",
                 "title": "WhatsApp",
+                "icon": __dirname + "/assets/icon/icon.png",
                 "webPreferences": {
                   "nodeIntegration": false,
                   "preload": join(__dirname, 'js', 'injected.js')


### PR DESCRIPTION
The icon was not shown when running the electron app directly on linux.

The problem came from the commit 7266f28b26b80fd537c2ca35458f0b6d9e5d6c1b, someone needs to test if this pull request would affect OSX.